### PR TITLE
Raise OutputError with helpful message if dot isn't installed

### DIFF
--- a/graphviz.gemspec
+++ b/graphviz.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
 	spec.has_rdoc = 'yard'
 
+	spec.add_runtime_dependency 'tty-which', '~> 0.3.0'
+
 	spec.add_development_dependency "yard"
 	spec.add_development_dependency "bundler", "~> 1.3"
 	spec.add_development_dependency "rspec", "~> 3.4.0"

--- a/lib/graphviz.rb
+++ b/lib/graphviz.rb
@@ -20,6 +20,7 @@
 
 require_relative "graphviz/version"
 require_relative "graphviz/graph"
+require 'tty-which'
 
 module Graphviz
 	# Signals that the process exited with a non-zero status.
@@ -47,9 +48,15 @@ module Graphviz
 		else
 			output_file = IO.pipe
 		end
-		
-		output, input = IO.pipe
-		pid = Process.spawn(options[:dot] || "dot", "-T#{output_format}", :out => output_file, :in => output)
+
+		dot_executable = options[:dot] || "dot"
+
+		unless TTY::Which.which(dot_executable)
+			raise OutputError, "#{dot_executable} must be installed to output graphs."
+		end
+
+                output, input = IO.pipe
+		pid = Process.spawn(dot_executable, "-T#{output_format}", :out => output_file, :in => output)
 		
 		output.close
 		

--- a/spec/graphviz/graph_spec.rb
+++ b/spec/graphviz/graph_spec.rb
@@ -44,5 +44,10 @@ digraph "G" {
 			
 			expect(File.exist? "test.pdf").to be true
 		end
+
+		it 'should raise an OutputError unless the dot executable is installed' do
+			expect { Graphviz.output(subject, :dot => 'foobarbaz') }
+				.to raise_error(Graphviz::OutputError, 'foobarbaz must be installed to output graphs.')
+		end
 	end
 end


### PR DESCRIPTION
Hey there,

Thanks for the gem, it's very useful to find an MIT-licensed alternative to https://github.com/glejeune/Ruby-Graphviz.

This is a small change that explicitly returns an OutputError when the dot executable is not installed.

I have opted to do the executable detection with https://rubygems.org/gems/tty-which, because this seems like the most robust, cross-platform solution. If you're not keen on adding a dependency then we could also take a more minimal approach, such as those outlined in https://stackoverflow.com/questions/2108727/which-in-ruby-checking-if-program-exists-in-path-from-ruby.