### PR TITLE
Fix Ruby 2.7 warning

### DIFF
--- a/graphviz.gemspec
+++ b/graphviz.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
 	spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 	spec.require_paths = ["lib"]
 
-	spec.has_rdoc = 'yard'
-
 	spec.add_dependency 'process-pipeline'
 
 	spec.add_development_dependency "yard"

--- a/graphviz.gemspec
+++ b/graphviz.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency 'process-pipeline'
 
 	spec.add_development_dependency "yard"
-	spec.add_development_dependency "bundler", "~> 1.3"
+	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "rspec", "~> 3.6"
 	spec.add_development_dependency "rake"
 end

--- a/lib/graphviz/graph.rb
+++ b/lib/graphviz/graph.rb
@@ -46,7 +46,7 @@ module Graphviz
 		def add_node(name = nil, **attributes)
 			name ||= "#{@name}N#{@nodes.count}"
 			
-			Node.new(name, self, attributes)
+			Node.new(name, self, **attributes)
 		end
 		
 		# Add a subgraph with a given name and attributes.
@@ -131,7 +131,7 @@ module Graphviz
 				node.dump_graph(buffer, indent + "\t", options)
 			end
 			
-			dump_edges(buffer, indent + "\t", options)
+			dump_edges(buffer, indent + "\t", **options)
 			
 			buffer.puts "#{indent}}"
 		end

--- a/spec/graphviz/graph_spec.rb
+++ b/spec/graphviz/graph_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Graphviz::Graph do
 	end
 
 	it "gets a node" do
-		foo = subject.add_node('Foo')
+		subject.add_node('Foo')
 		bar = subject.add_node('Bar')
 		bar.add_node('Baz')
 		expect(subject.get_node('Baz')).to be_an(Array)
@@ -58,7 +58,7 @@ RSpec.describe Graphviz::Graph do
 end
 
 	it "checks if a node exists" do
-		foo = subject.add_node('Foo')
+		subject.add_node('Foo')
 		bar = subject.add_node('Bar')
 		bar.add_node('Baz')
 		expect(subject.node_exists?('Baz')).to be true


### PR DESCRIPTION
warning: Using the last argument as keyword parameters is deprecated

May need changes from 
* https://github.com/ioquatix/process-pipeline/pull/1
* https://github.com/ioquatix/process-group/pull/4