### PR TITLE
Fix compatibility with Ruby 3.0

### DIFF
--- a/lib/graphviz/graph.rb
+++ b/lib/graphviz/graph.rb
@@ -127,8 +127,8 @@ module Graphviz
 				buffer.puts "#{indent}\t#{name}=#{dump_value(value)};"
 			end
 			
-			@nodes.each do |name, node|
-				node.dump_graph(buffer, indent + "\t", options)
+			@nodes.each do |_name, node|
+				node.dump_graph(buffer, indent + "\t", **options)
 			end
 			
 			dump_edges(buffer, indent + "\t", **options)

--- a/lib/graphviz/node.rb
+++ b/lib/graphviz/node.rb
@@ -79,7 +79,7 @@ module Graphviz
 			@name
 		end
 		
-		def dump_graph(buffer, indent, options)
+		def dump_graph(buffer, indent, **options)
 			node_attributes_text = dump_attributes(@attributes)
 			node_name = dump_value(self.identifier)
 			


### PR DESCRIPTION
Current release (on Ruby 3.0) will raise for example

```
#<Thread:0x00007fc1d20fe9c0 /Users/jasl/Workspaces/Ruby/graphviz/lib/graphviz.rb:46 run> terminated with exception (report_on_exception is true):
/Users/jasl/Workspaces/Ruby/graphviz/lib/graphviz/graph.rb:121:in `dump_graph': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
	from /Users/jasl/Workspaces/Ruby/graphviz/lib/graphviz/graph.rb:131:in `block in dump_graph'
	from /Users/jasl/Workspaces/Ruby/graphviz/lib/graphviz/graph.rb:130:in `each'
	from /Users/jasl/Workspaces/Ruby/graphviz/lib/graphviz/graph.rb:130:in `dump_graph'
	from /Users/jasl/Workspaces/Ruby/graphviz/lib/graphviz.rb:47:in `block in output'
```