### PR TITLE
Fix add_subgraph on Ruby 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /coverage/
 /doc/
 /pkg/
+/test.pdf
 /tmp/
 
 # rspec failure tracking

--- a/lib/graphviz/graph.rb
+++ b/lib/graphviz/graph.rb
@@ -54,7 +54,7 @@ module Graphviz
 		def add_subgraph(name = nil, **attributes)
 			name ||= "#{@name}S#{@nodes.count}"
 			
-			subgraph = Graph.new(name, self, attributes)
+			subgraph = Graph.new(name, self, **attributes)
 			
 			self << subgraph
 			

--- a/spec/graphviz/graph_spec.rb
+++ b/spec/graphviz/graph_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Graphviz::Graph do
 		expect(subject.get_node('Foo').first).to be_a(Graphviz::Node)
 		expect(subject.get_node('Nothing')).to be_an(Array)
 		expect(subject.get_node('Nothing').size).to eq 0
-end
+	end
 
 	it "checks if a node exists" do
 		subject.add_node('Foo')
@@ -69,5 +69,11 @@ end
 		expect do
 			Graphviz.output(subject, :dot => 'foobarbaz')
 		end.to raise_error(Errno::ENOENT, 'No such file or directory - foobarbaz')
+	end
+
+	describe "#add_subgraph" do
+		it "does not crash" do
+			expect { subject.add_subgraph }.to_not raise_error
+		end
 	end
 end


### PR DESCRIPTION
Hi!

`add_subgraph` did not have tests and was not adapted for Ruby 3. This fixes that.

I am using it in https://github.com/mvidner/yard-medoosa BTW.